### PR TITLE
Handy functions

### DIFF
--- a/examples/json.py
+++ b/examples/json.py
@@ -43,11 +43,9 @@ def quoted():
 @generate
 def array():
     yield lbrack
-    first = yield value
-    rest = yield (comma >> value).many()
+    elements = yield value.sep_by(comma)
     yield rbrack
-    rest.insert(0, first)
-    return rest
+    return elements
 
 @generate
 def object_pair():
@@ -59,11 +57,9 @@ def object_pair():
 @generate
 def json_object():
     yield lbrace
-    first = yield object_pair
-    rest = yield (comma >> object_pair).many()
+    members = yield object_pair.sep_by(comma)
     yield rbrace
-    rest.insert(0, first)
-    return dict(rest)
+    return dict(members)
 
 value = quoted | number | json_object | array | true | false | null
 

--- a/examples/json.py
+++ b/examples/json.py
@@ -60,7 +60,7 @@ def object_pair():
 def json_object():
     yield lbrace
     first = yield object_pair
-    rest = yield (comma >> value).many()
+    rest = yield (comma >> object_pair).many()
     yield rbrace
     rest.insert(0, first)
     return dict(rest)

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -141,6 +141,15 @@ class Parser(object):
     def at_least(self, n):
         return self.times(n, float('inf'))
 
+    def sep_by(self, sep, *, min=0, max=float('inf')):
+        zero_times = success([])
+        if max == 0:
+            return zero_times
+        res = self.times(1) + (sep >> self).times(min - 1, max - 1)
+        if min == 0:
+            res |= zero_times
+        return res
+
     def desc(self, description):
         return self | fail(description)
 

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -35,8 +35,8 @@ class Result(namedtuple('Result', 'status index value furthest expected')):
     @staticmethod
     def failure(index, expected): return Result(False, -1, None, index, expected)
 
-    # collect the furthest failure from self and other
     def aggregate(self, other):
+        """Collect the furthest failure from self and other."""
         if not other: return self
         if self.furthest >= other.furthest: return self
 

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -110,7 +110,7 @@ class Parser(object):
 
     def times(self, min, max=None):
         # max=None means exactly min
-        # min=max=None means from 0 to infinity
+        # max can also be float('inf')
         if max is None:
             max = min
 

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -194,7 +194,7 @@ def alt(*parsers):
 
     return alt_parser
 
-def seq(*parsers):
+def seq(*parsers, f=None):
     if not parsers:
         return success([])
 
@@ -209,6 +209,8 @@ def seq(*parsers):
             index = result.index
             values.append(result.value)
 
+        if f is not None:
+            values = f(*values)
         return Result.success(index, values).aggregate(result)
 
     return seq_parser

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -106,7 +106,7 @@ class Parser(object):
         return self >> success(res)
 
     def many(self):
-        return self.times(0, float('inf'))
+        return self.at_least(0)
 
     def times(self, min, max=None):
         # max=None means exactly min
@@ -139,7 +139,7 @@ class Parser(object):
         return self.times(0, n)
 
     def at_least(self, n):
-        return self.times(n) + self.many()
+        return self.times(n, float('inf'))
 
     def desc(self, description):
         return self | fail(description)

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -154,6 +154,16 @@ class Parser(object):
 
         return marked
 
+    def should_fail(self):
+        @Parser
+        def fail_parser(stream, index):
+            res = self(stream, index)
+            if res.status:
+                return Result.failure(index, 'should fail')
+            return Result.success(index, res)
+
+        return fail_parser
+
     def __add__(self, other):
         return seq(self, other).map(lambda res: res[0] + res[1])
 

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -1,4 +1,4 @@
-from parsy import string, regex, generate, ParseError, letter, digit
+from parsy import *
 import pdb
 import unittest
 

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -165,5 +165,69 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, then_digit.parse, 'xyzwv1')
         self.assertRaises(ParseError, then_digit.parse, 'x1')
 
+    def test_should_fail(self):
+        not_a_digit = digit.should_fail() >> regex(r'.*')
+
+        self.assertEqual(not_a_digit.parse('a'), 'a')
+        self.assertEqual(not_a_digit.parse('abc'), 'abc')
+        self.assertEqual(not_a_digit.parse('a10'), 'a10')
+        self.assertEqual(not_a_digit.parse(''), '')
+
+        self.assertRaises(ParseError, not_a_digit.parse, '8')
+        self.assertRaises(ParseError, not_a_digit.parse, '8ab')
+
+    def test_sep_by(self):
+        digit_list = digit.map(int).sep_by(string(','))
+
+        self.assertEqual(digit_list.parse('1,2,3,4'), [1, 2, 3, 4])
+        self.assertEqual(digit_list.parse('9,0,4,7'), [9, 0, 4, 7])
+        self.assertEqual(digit_list.parse('3,7'), [3, 7])
+        self.assertEqual(digit_list.parse('8'), [8])
+        self.assertEqual(digit_list.parse(''), [])
+
+        self.assertRaises(ParseError, digit_list.parse, '8,')
+        self.assertRaises(ParseError, digit_list.parse, ',9')
+        self.assertRaises(ParseError, digit_list.parse, '82')
+        self.assertRaises(ParseError, digit_list.parse, '7.6')
+
+    def test_sep_by_with_min_and_max(self):
+        digit_list = digit.map(int).sep_by(string(','), min=2, max=4)
+
+        self.assertEqual(digit_list.parse('1,2,3,4'), [1, 2, 3, 4])
+        self.assertEqual(digit_list.parse('9,0,4,7'), [9, 0, 4, 7])
+        self.assertEqual(digit_list.parse('3,7'), [3, 7])
+
+        self.assertRaises(ParseError, digit_list.parse, '8')
+        self.assertRaises(ParseError, digit_list.parse, '')
+        self.assertRaises(ParseError, digit_list.parse, '8,')
+        self.assertRaises(ParseError, digit_list.parse, ',9')
+        self.assertRaises(ParseError, digit_list.parse, '82')
+        self.assertRaises(ParseError, digit_list.parse, '7.6')
+
+    def test_seq(self):
+        int_ = digit.at_least(1).map(''.join).map(int)
+        addition = seq(int_, string('+'), int_).map(lambda l: l[0] + l[2])
+
+        self.assertEqual(addition.parse('2+2'), 4)
+        self.assertEqual(addition.parse('9+4'), 13)
+        self.assertEqual(addition.parse('20+19'), 39)
+
+        self.assertRaises(ParseError, addition.parse, '32')
+        self.assertRaises(ParseError, addition.parse, '3+')
+        self.assertRaises(ParseError, addition.parse, '5-67')
+
+    def test_seq_with_post_processing(self):
+        int_ = digit.at_least(1).map(''.join).map(int)
+        addition = seq(int_, string('+'), int_, f=lambda a, plus, b: a + b)
+
+        self.assertEqual(addition.parse('2+2'), 4)
+        self.assertEqual(addition.parse('9+4'), 13)
+        self.assertEqual(addition.parse('20+19'), 39)
+
+        self.assertRaises(ParseError, addition.parse, '32')
+        self.assertRaises(ParseError, addition.parse, '3+')
+        self.assertRaises(ParseError, addition.parse, '5-67')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
An implementation of a few ideas found in Parsec:
- `parser.should_fail()` succeeds (consuming no input) if `parser` fails
  - `parser << other.should_fail()` — this is how you do Parsec's `notFollowedBy`
  - `(other.should_fail() >> parser).many()` for Parsec's `manyTill`
- `seq(*parsers, f=...)` allows for easier post-processing, compare [before](https://github.com/bugaevc/parsy/blob/handy_functions/test/test_parsy.py#L209) and [after](https://github.com/bugaevc/parsy/blob/handy_functions/test/test_parsy.py#L221)
- `parser.sep_by(sep)` is roughly equivalent to `parser.times(1) + (sep >> parser).many()`. It can however handle zero-times case and has `min` and `max` keyword-only arguments.
  - Python-style tuple literals would be `lparen >> (expr.sep_by(comma, min=2) | expr.times(1) << comma | success([])) << rparen`
